### PR TITLE
Nearing with Hysterisis and Offset for Block Stack

### DIFF
--- a/planning.py
+++ b/planning.py
@@ -216,6 +216,9 @@ def queue_end(cur):
 def queue_bin(cur, n, off):
     global wp_queue
 
+    # Make sure to add in the robot's constants
+    off += A_BS + L
+
     # If the index is not a bin, go to end
     if n <= 0 or n >= 11:
         queue_end(cur)


### PR DESCRIPTION
What the title says. Added a method `wp_near` to determine if we are near the current queued goal. Added an offset to `queue_turnin` so that the `off` parameter is the offset of the center of the block.